### PR TITLE
bin/rgbpm: Use env shebang instead of hardcoding bash

### DIFF
--- a/bin/rgbpm
+++ b/bin/rgbpm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # rgbpm - Copyright (c) 2019 Matthias C. Hormann
 # apply replay gain (mp3gain2) and BPM (bpm-calc) to all folders below and including specified one


### PR DESCRIPTION
Set #!/usr/bin/env bash instead of #!/bin/bash for better compatibility

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>