### PR TITLE
Only call av_register_all() if libavformat is older than version 58.9.100

### DIFF
--- a/src/scan.c
+++ b/src/scan.c
@@ -69,9 +69,9 @@ int scan_init(unsigned nb_files) {
 	 * It is now useless
 	 * https://github.com/FFmpeg/FFmpeg/blob/70d25268c21cbee5f08304da95be1f647c630c15/doc/APIchanges#L86
 	 */
-  if (avformat_version() < AV_VERSION_INT(58,9,100))
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58,9,100)
     av_register_all();
-
+#endif
 	av_log_set_callback(scan_av_log);
 
 	scan_nb_files = nb_files;


### PR DESCRIPTION
This patch adds a preprocessor #define to ensure we only call the deprecated function av_register_all() when working with versions of libavformat older than 58.9.100.

The function av_register_all() was removed in ffmpeg 5.0.