### PR TITLE
CMakeLists.txt: Raise minimum version to 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Modifications Copyright (C) 2019 Matthias C. Hormann <mhormann@gmx.de>
 # This file is released under the 2 clause BSD license, see COPYING
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.31...4.0)
 PROJECT(loudgain C CXX)
 
 SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/" ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
In July 2023, CMake deprecated backwards compatibility for versions older than 3.5. CMake 4.0 finally drops support, causing all packages still relying on older behaviour to fail to build from source.

No changes are needed with the higher version requirement.